### PR TITLE
Improve clarity with item ID usage

### DIFF
--- a/src/main/java/paulevs/vbe/block/VanillaLeavesWrapper.java
+++ b/src/main/java/paulevs/vbe/block/VanillaLeavesWrapper.java
@@ -54,6 +54,6 @@ public class VanillaLeavesWrapper extends VBELeavesBlock {
 	public List<ItemStack> getDropList(Level level, int x, int y, int z, BlockState state, int meta) {
 		int count = LEAVES.getDropCount(level.random);
 		if (count == 0) return Collections.emptyList();
-		return Collections.singletonList(new ItemStack(Block.SAPLING.id, count, this.meta));
+		return Collections.singletonList(new ItemStack(Block.SAPLING.asItem().id, count, this.meta));
 	}
 }

--- a/src/main/java/paulevs/vbe/utils/ItemConverter.java
+++ b/src/main/java/paulevs/vbe/utils/ItemConverter.java
@@ -13,13 +13,13 @@ public class ItemConverter {
 		VBEBlocks.BIRCH_LOG
 	};
 	
-	public static int getID(int id, int damage) {
+	public static int getID(int itemId, int damage) {
 		Item item = null;
-		if (id == Block.STONE_SLAB.id && VBE.ENHANCED_SLABS.getValue()) item = VBEBlocks.getHalfSlabByMeta(damage).asItem();
-		if (id == Block.LOG.id) item = VBEBlocks.getLogByMeta(damage).asItem();
-		if (id == Block.LEAVES.id) item = VBEBlocks.getLeavesByMeta(damage).asItem();
-		if (id == Item.woodDoor.id) item = VBEItems.OAK_DOOR.asItem();
-		if (id == Item.ironDoor.id) item = VBEItems.IRON_DOOR.asItem();
+		if (itemId == Block.STONE_SLAB.asItem().id && VBE.ENHANCED_SLABS.getValue()) item = VBEBlocks.getHalfSlabByMeta(damage).asItem();
+		if (itemId == Block.LOG.asItem().id) item = VBEBlocks.getLogByMeta(damage).asItem();
+		if (itemId == Block.LEAVES.asItem().id) item = VBEBlocks.getLeavesByMeta(damage).asItem();
+		if (itemId == Item.woodDoor.id) item = VBEItems.OAK_DOOR.asItem();
+		if (itemId == Item.ironDoor.id) item = VBEItems.IRON_DOOR.asItem();
 		return item == null ? -1 : item.id;
 	}
 	
@@ -27,11 +27,11 @@ public class ItemConverter {
 		return id == Block.STONE_SLAB.id && VBE.ENHANCED_SLABS.getValue() ? damage : 0;
 	}
 	
-	public static boolean resetDamage(int id) {
+	public static boolean resetDamage(int itemId) {
 		for (Block log : LOGS) {
 			Item item = log.asItem();
 			if (item == null) continue;
-			if (id == item.id) return true;
+			if (itemId == item.id) return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
This PR isn't needed since vanilla blocks share the same id space as items. So there are no bugs being caused by it.
But, the below is technically more correct and might encourage newer modders to correctly get the item id when doing block to item id comparisons.
Up to you of course if you want to add it into the code or not, since it doesn't make any functional difference here.